### PR TITLE
feat: 테라폼 Elasticache redis 설정

### DIFF
--- a/production/elasticache.tf
+++ b/production/elasticache.tf
@@ -1,0 +1,59 @@
+resource "aws_elasticache_cluster" "bibbi-elc" {
+  cluster_id           = "bibbi-redis"
+  engine               = "redis"
+  engine_version       = "7.0"
+  node_type            = "cache.t2.micro"
+  num_cache_nodes      = 1
+  port                 = 6379
+  parameter_group_name = "default.redis7"
+}
+
+resource "aws_elasticache_subnet_group" "elc-subnet" {
+  name       = "bibbi-elc-subnet"
+  subnet_ids = aws_subnet.private.*.id
+
+  tags = {
+    Name = "Elc subnet group"
+  }
+}
+
+resource "aws_security_group" "elc-sg" {
+  name        = "elasticache-sg"
+  description = "Security group for elc"
+  vpc_id      = aws_vpc.bibbi-vpc.id
+
+  tags = {
+    Name = "Elc SG"
+  }
+}
+
+resource "aws_security_group_rule" "ingress_redis" {
+  security_group_id = aws_security_group.elc-sg.id
+  type              = "ingress"
+  from_port         = 6379
+  to_port           = 6379
+  protocol          = "TCP"
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "allow incoming traffic on TCP 6379"
+}
+
+# 인바운드 수정 필요
+resource "aws_security_group_rule" "ingress_ssh" {
+  security_group_id = aws_security_group.elc-sg.id
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "TCP"
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "allow incoming SSH traffic"
+}
+
+resource "aws_security_group_rule" "egress_all" {
+  security_group_id = aws_security_group.elc-sg.id
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "allow all outbound traffic"
+}

--- a/production/elasticache.tf
+++ b/production/elasticache.tf
@@ -27,6 +27,7 @@ resource "aws_security_group" "elc-sg" {
   }
 }
 
+# 인바운드 수정 필요
 resource "aws_security_group_rule" "ingress_redis" {
   security_group_id = aws_security_group.elc-sg.id
   type              = "ingress"


### PR DESCRIPTION
단일 노드 Redis(클러스터 모드 비활성화됨) 클러스터 (저사양)
private subnet에 위치
보안그룹 인바운드 - 원래는 운영/개발 ec2에 대해서만 port 6379, 22를 열어야 함 (지금은 모든 ip에 대해 엶)
보안그룹 아웃바운드 - 모두 허용